### PR TITLE
fix: work with both the beta and app store versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ By Jason Snell <jsnell@sixcolors.com> with enormous contributions by many others
 
 ## About this project
 
-This script is meant to be used inside [Scriptable](https://scriptable.app) to generate iOS home screen widgets. **This version requires the latest Scriptable 1.5.1 beta. [Sign up for it here](https://testflight.apple.com/join/klHcZHjN).**
+This script is meant to be used inside [Scriptable](https://scriptable.app) to generate iOS home screen widgets. The trend line feature requires the latest Scriptable 1.5.1 beta. [Sign up for it here](https://testflight.apple.com/join/klHcZHjN).
 
 It uses data from the [PurpleAir network](https://www2.purpleair.com) of low-cost, consumer air quality sensors to display your local air quality, including AQI rating and trend.
 

--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -105,7 +105,7 @@ const LEVEL_ATTRIBUTES = [
     darkStartColor: "333333",
     darkEndColor: "000000",
     darkTextColor: "ff7600",
-   },
+  },
   {
     threshold: 50,
     label: "Moderate",
@@ -274,17 +274,23 @@ async function run() {
 
     listWidget.addSpacer(5);
 
-    let scoreStack = listWidget.addStack()
+    if (listWidget.addStack) {
+      const scoreStack = listWidget.addStack()
 
-    const content = scoreStack.addText(aqiText);
-    content.textColor = textColor;
-    content.font = Font.mediumSystemFont(30);
+      const content = scoreStack.addText(aqiText);
+      content.textColor = textColor;
+      content.font = Font.mediumSystemFont(30);
 
-  const trendSymbol = createSymbol(aqiTrend);
-  const trendImg = scoreStack.addImage(trendSymbol.image);
-  trendImg.resizable = false;
-  trendImg.tintColor = textColor;
-  trendImg.imageSize = new Size(30, 38);
+      const trendSymbol = createSymbol(aqiTrend);
+      const trendImg = scoreStack.addImage(trendSymbol.image);
+      trendImg.resizable = false;
+      trendImg.tintColor = textColor;
+      trendImg.imageSize = new Size(30, 38);
+    } else {
+      const content = listWidget.addText(aqiText);
+      content.textColor = textColor;
+      content.font = Font.mediumSystemFont(30);
+    }
 
     const wordLevel = listWidget.addText(level.label);
     wordLevel.textColor = textColor;


### PR DESCRIPTION
The app store version currently does not have the `ListWidget#addStack` method. This changes the widget to check whether it's availble, and use it if so. If not, it falls back to omitting the trend symbol.

I made this change because the Scriptable beta is full, and is likely to remain so. This condition can of course be removed once the app store version supports this API.