### PR TITLE
fix: don't crash if given a weird threshold 

### DIFF
--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -196,8 +196,8 @@ function calculateLevel(aqi) {
     darkStartColor = "009900",
     darkEndColor = "007700",
     darkTextColor = "000000",
-    threshold,
-  } = LEVEL_ATTRIBUTES.find(({ threshold }) => level > threshold);
+    threshold = -Infinity,
+  } = LEVEL_ATTRIBUTES.find(({ threshold }) => level > threshold) || {};
 
   return {
     label,


### PR DESCRIPTION
If threshold is a very low value, like -100, then the `find` call will return `undefined` and the destructuring assignment will fail, rather than using the default values as expected. To ensure this works, default to an empty object so all the defaults will be used, and fill in a default for `threshold`.