### PR TITLE
Fix: only get location if SENSOR_ID is not provided; find nearest sensor in O(n) time

### DIFF
--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -82,19 +82,19 @@ async function getSensorId({ latitude, longitude }) {
   const typeIndex = fields.indexOf("Type");
   const OUTDOOR = 0;
 
-  const [closestSensor] = data
-    .filter((datum) => datum[typeIndex] === OUTDOOR)
-    .sort(
-      (a, b) =>
-        haversine(
-          { latitude, longitude },
-          { latitude: a[latIndex], longitude: a[lonIndex] }
-        ) -
-        haversine(
-          { latitude, longitude },
-          { latitude: b[latIndex], longitude: b[lonIndex] }
-        )
+  let closestSensor;
+  let closestDistance = Infinity;
+
+  for (const location of data.filter((datum) => datum[typeIndex] === OUTDOOR)) {
+    const distanceFromLocation = haversine(
+      { latitude, longitude },
+      { latitude: location[latIndex], longitude: location[lonIndex] }
     );
+    if (distanceFromLocation < closestDistance) {
+      closestDistance = distanceFromLocation;
+      closestSensor = location;
+    }
+  }
 
   return closestSensor ? closestSensor[sensorIdIndex] : DEFAULT_SENSOR_ID;
 }

--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -51,11 +51,13 @@ const DEFAULT_SENSOR_ID = 69223;
 /**
  * Get the closest PurpleAir sensorId to the given location
  *
- * @param {LatLon} location
  * @returns {Promise<number>}
  */
-async function getSensorId({ latitude, longitude }) {
+async function getSensorId() {
   if (SENSOR_ID) return SENSOR_ID;
+
+  /** @type {LatLon} */
+  const { latitude, longitude } = await Location.current();
 
   const BOUND_OFFSET = 0.05;
 
@@ -320,9 +322,7 @@ async function run() {
   listWidget.setPadding(10, 15, 10, 10);
 
   try {
-    /** @type {LatLon} */
-    const deviceLocation = await Location.current();
-    const sensorId = await getSensorId(deviceLocation);
+    const sensorId = await getSensorId();
     console.log(`Using sensor ID: ${sensorId}`);
 
     const data = await getSensorData(sensorId);


### PR DESCRIPTION
This PR adds improvements suggested in #10, and builds on #8. Namely:

* Don't needlessly get the user's location if they have provided a sensor id
* Walk through the retrieved locations once to find the closest one, instead of sorting them all

Thanks to @lickel and @eventualbuddha for the suggestions!

P.S. @jasonsnell good luck with the draft next week! Hoping you crush iMyke! 🤞 
P.P.S. Happy Birthday! 🎉  🍰  5️⃣ 0️⃣ 