### PR TITLE
fix: properly support A channel-only sensors

### DIFF
--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -34,7 +34,7 @@ const SENSOR_ID = args.widgetParameter;
  * @typedef {object} SensorData
  * @property {string} val
  * @property {string} adj1
- * @property {string} adj2
+ * @property {string} [adj2]
  * @property {number} ts
  * @property {string} hum
  * @property {string} loc
@@ -345,7 +345,7 @@ function computePM(sensorData) {
   const adj1 = Number.parseInt(sensorData.adj1, 10);
   const adj2 = Number.parseInt(sensorData.adj2, 10);
   const hum = Number.parseInt(sensorData.hum, 10);
-  const dataAverage = (adj1 + adj2) / 2;
+  const dataAverage = isNaN(adj2) ? adj1 : (adj1 + adj2) / 2;
   console.log(`PM2.5 number is ${dataAverage}.`)
   if (dataAverage < 250) {
     console.log(`Using EPA calculation.`)


### PR DESCRIPTION
Some sensors only have the A channel. I’m assuming these are indoor sensors, as my indoor sensor only has an A channel. Here’s another example (that is not my home sensor): https://www.purpleair.com/map?opt=1/mAQI/a10/cC5&select=72135#14/37.77009/-122.22338. In this case, I presume the right thing to do to get the average is to just use the A channel exclusively.