### PR TITLE
Fallback to `stats.pm2.5` field when `stats.pm2.5_cf_1` is undefined

### DIFF
--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -242,7 +242,7 @@ async function getSensorData(sensorId) {
     }
     return {
       val: json.sensor,
-      adj: json.sensor.stats["pm2.5_cf_1"],
+      adj: json.sensor.stats["pm2.5_cf_1"] ?? json.sensor.stats["pm2.5"],
       ts: json.sensor.last_seen,
       hum: json.sensor.humidity,
       loc: replaceHTMLEntities(json.sensor.name),

--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -81,7 +81,7 @@ function getCachedData(fileName) {
 }
 
 /**
- * Wite JSON to a local file
+ * Write JSON to a local file
  *
  * @param {string} fileName
  * @param {object} data


### PR DESCRIPTION
When trying to set up the widget for myself, I noticed that the `pm2.5_cf_1` field wasn't defined, resulting in the widget not displaying any value. 
<img width="584" alt="CleanShot 2023-09-21 at 01 24 39@2x" src="https://github.com/jasonsnell/PurpleAir-AQI-Scriptable-Widget/assets/1409924/26641b6e-60dc-4a6b-8ca9-eee16dceb79f">

 I don't know if `json.sensor.stats["pm2.5_cf_1"]` is a typo and should be `json.sensor["pm2.5_cf_1"]` instead or if `pm2.5_cf_1` _used_ to be available on the `stats` object but in any case, this PR fixed the issue for me so feel free to merge it if that's The Right Way™️ to do it 😁 