### PR TITLE
Update EPA calculation to use new formula released October 2021

### DIFF
--- a/purpleair-aqi.js
+++ b/purpleair-aqi.js
@@ -242,7 +242,7 @@ async function getSensorData(sensorId) {
     }
     return {
       val: json.sensor,
-      adj: json.sensor.stats["pm2.5_cf_1"],
+      adj: json.sensor["pm2.5_cf_1"], // as of Sep 2023 Purple Air API has pm2.5_cf_1 at top level of JSON
       ts: json.sensor.last_seen,
       hum: json.sensor.humidity,
       loc: replaceHTMLEntities(json.sensor.name),


### PR DESCRIPTION
EPA's humidity-based formula was tweaked a while ago -- https://cfpub.epa.gov/si/si_public_record_report.cfm?dirEntryId=353088&Lab=CEMM (slide 26 of the PDF). The tweak has the biggest impact when pm2.5 levels are high.

I noticed that Jason's widget and my Shortcut (which implemented the 2018 formula) consistently understated the AQI during the last set of smoky days in the Bay Area Sep 19-23 (Jason was probably traveling and focused on Relay's Podcastathon). These changes should make the widget AQI be consistent with what is shown on Purple Air's map. I double checked the formula; any remaining errors are mine.

While debugging I also noticed PurpleAir has moved "pm2.5_cf_1" to the top level of the sensor JSON. This PR also includes a change to getSensorData so that it pulls it correctly. @eramdam addresses the same thing using a fallback approach in the other PR https://github.com/jasonsnell/PurpleAir-AQI-Scriptable-Widget/pull/39.

Thanks for all you and your merry band do @jasonsnell! I've been a listener/follower of your work for well over a decade now as a SixColors and Incomparable member. Great stuff. 